### PR TITLE
Set up leaderboard for 2016

### DIFF
--- a/checkin2015/urls.py
+++ b/checkin2015/urls.py
@@ -17,41 +17,37 @@ urlpatterns = patterns(
     url(r'^chaining/', include('smart_selects.urls')),
     url(r'^checkin/complete/$', TemplateView.as_view(template_name='survey/thanks.html'), name='complete'),
 
-    # Leaderboard
-    url(r'^leaderboard/$',
+    # Leaderboard by year
+    url(r'^leaderboard/(?P<year>[\w\.-]*)/$',
         'leaderboard.views.latest_leaderboard', name="all"),
 
 
-    url(r'^leaderboard/all/subteams/$',
+    url(r'^leaderboard/(?P<year>[\w\.-]*)/all/subteams/$',
         'leaderboard.views.latest_leaderboard', name="subteams_all"),
-    url(r'^leaderboard/all/all/subteams/(?P<parentid>[\w\.-]*)/$',
+    url(r'^leaderboard/(?P<year>[\w\.-]*)/all/all/subteams/(?P<parentid>[\w\.-]*)/$',
         'leaderboard.views.latest_leaderboard', name="subteams"),
-    url(r'^leaderboard/(?P<sector>[\w\.-]*)/(?P<size>[\w\.-]*)/subteams/(?P<parentid>[\w\.-]*)/(?P<selected_month>[\w\.-]*)/$',
+    url(r'^leaderboard/(?P<year>[\w\.-]*)/(?P<sector>[\w\.-]*)/(?P<size>[\w\.-]*)/subteams/(?P<parentid>[\w\.-]*)/(?P<selected_month>[\w\.-]*)/$',
         'leaderboard.views.latest_leaderboard', name="subteams_months"),
 
 
-    url(r'^leaderboard/(?P<selected_month>[\w\.-]*)/$',
+    url(r'^leaderboard/(?P<year>[\w\.-]*)/(?P<selected_month>[\w\.-]*)/$',
         'leaderboard.views.latest_leaderboard', name="all_sizes_all_months"),
-    url(r'^leaderboard/(?P<size>[\w\.-]*)/(?P<selected_month>[\w\.-]*)/$',
+    url(r'^leaderboard/(?P<year>[\w\.-]*)/(?P<size>[\w\.-]*)/(?P<selected_month>[\w\.-]*)/$',
         'leaderboard.views.latest_leaderboard', name="all_sizes_all_months"),
-    url(r'^leaderboard/(?P<size>[\w\.-]*)/$',
+    url(r'^leaderboard/(?P<year>[\w\.-]*)/(?P<size>[\w\.-]*)/$',
         'leaderboard.views.latest_leaderboard', name="all"),
 
-    url(r'^leaderboard/(?P<sector>[\w\.-]*)/$',
+    url(r'^leaderboard/(?P<year>[\w\.-]*)/(?P<sector>[\w\.-]*)/$',
         'leaderboard.views.latest_leaderboard', name="all"),
-    url(r'^leaderboard/(?P<sector>[\w\.-]*)/(?P<size>[\w\.-]*)/(?P<selected_month>[\w\.-]*)/$',
+    url(r'^leaderboard/(?P<year>[\w\.-]*)/(?P<sector>[\w\.-]*)/(?P<size>[\w\.-]*)/(?P<selected_month>[\w\.-]*)/$',
         'leaderboard.views.latest_leaderboard', name="all"),
-    url(r'^leaderboard/(?P<sector>[\w\.-]*)/(?P<selected_month>[\w\.-]*)/$',
+    url(r'^leaderboard/(?P<year>[\w\.-]*)/(?P<sector>[\w\.-]*)/(?P<selected_month>[\w\.-]*)/$',
         'leaderboard.views.latest_leaderboard', name="all"),
 
-
-
-
-
-    # individual company pages
-    url(r'^companies/$', 'leaderboard.views.company', name="allcompany"),
-    url(r'^companies/(?P<employerid>[\w\.-]*)/$', 'leaderboard.views.company', name="companies"),
-    url(r'^companies/(?P<employerid>[\w\.-]*)/(?P<teamid>[\w\.-]*)/$', 'leaderboard.views.company', name="teams"),
+    # individual company pages by year
+    url(r'^companies/(?P<year>[\w\.-]*)/$', 'leaderboard.views.company', name="allcompany"),
+    url(r'^companies/(?P<year>[\w\.-]*)/(?P<employerid>[\w\.-]*)/$', 'leaderboard.views.company', name="companies"),
+    url(r'^companies/(?P<year>[\w\.-]*)/(?P<employerid>[\w\.-]*)/(?P<teamid>[\w\.-]*)/$', 'leaderboard.views.company', name="teams"),
 
     # Admin
     url(r'^admin/', include(admin.site.urls)),

--- a/checkin2015/urls.py
+++ b/checkin2015/urls.py
@@ -18,36 +18,36 @@ urlpatterns = patterns(
     url(r'^checkin/complete/$', TemplateView.as_view(template_name='survey/thanks.html'), name='complete'),
 
     # Leaderboard by year
-    url(r'^leaderboard/(?P<year>[\w\.-]*)/$',
+    url(r'^leaderboard/(?P<year>[0-9]{4})/$',
         'leaderboard.views.latest_leaderboard', name="all"),
 
 
-    url(r'^leaderboard/(?P<year>[\w\.-]*)/all/subteams/$',
+    url(r'^leaderboard/(?P<year>[0-9]{4})/all/subteams/$',
         'leaderboard.views.latest_leaderboard', name="subteams_all"),
-    url(r'^leaderboard/(?P<year>[\w\.-]*)/all/all/subteams/(?P<parentid>[\w\.-]*)/$',
+    url(r'^leaderboard/(?P<year>[0-9]{4})/all/all/subteams/(?P<parentid>[\w\.-]*)/$',
         'leaderboard.views.latest_leaderboard', name="subteams"),
-    url(r'^leaderboard/(?P<year>[\w\.-]*)/(?P<sector>[\w\.-]*)/(?P<size>[\w\.-]*)/subteams/(?P<parentid>[\w\.-]*)/(?P<selected_month>[\w\.-]*)/$',
+    url(r'^leaderboard/(?P<year>[0-9]{4})/(?P<sector>[\w\.-]*)/(?P<size>[\w\.-]*)/subteams/(?P<parentid>[\w\.-]*)/(?P<selected_month>[\w\.-]*)/$',
         'leaderboard.views.latest_leaderboard', name="subteams_months"),
 
 
-    url(r'^leaderboard/(?P<year>[\w\.-]*)/(?P<selected_month>[\w\.-]*)/$',
+    url(r'^leaderboard/(?P<year>[0-9]{4})/(?P<selected_month>[\w\.-]*)/$',
         'leaderboard.views.latest_leaderboard', name="all_sizes_all_months"),
-    url(r'^leaderboard/(?P<year>[\w\.-]*)/(?P<size>[\w\.-]*)/(?P<selected_month>[\w\.-]*)/$',
+    url(r'^leaderboard/(?P<year>[0-9]{4})/(?P<size>[\w\.-]*)/(?P<selected_month>[\w\.-]*)/$',
         'leaderboard.views.latest_leaderboard', name="all_sizes_all_months"),
-    url(r'^leaderboard/(?P<year>[\w\.-]*)/(?P<size>[\w\.-]*)/$',
+    url(r'^leaderboard/(?P<year>[0-9]{4})/(?P<size>[\w\.-]*)/$',
         'leaderboard.views.latest_leaderboard', name="all"),
 
-    url(r'^leaderboard/(?P<year>[\w\.-]*)/(?P<sector>[\w\.-]*)/$',
+    url(r'^leaderboard/(?P<year>[0-9]{4})/(?P<sector>[\w\.-]*)/$',
         'leaderboard.views.latest_leaderboard', name="all"),
-    url(r'^leaderboard/(?P<year>[\w\.-]*)/(?P<sector>[\w\.-]*)/(?P<size>[\w\.-]*)/(?P<selected_month>[\w\.-]*)/$',
+    url(r'^leaderboard/(?P<year>[0-9]{4})/(?P<sector>[\w\.-]*)/(?P<size>[\w\.-]*)/(?P<selected_month>[\w\.-]*)/$',
         'leaderboard.views.latest_leaderboard', name="all"),
-    url(r'^leaderboard/(?P<year>[\w\.-]*)/(?P<sector>[\w\.-]*)/(?P<selected_month>[\w\.-]*)/$',
+    url(r'^leaderboard/(?P<year>[0-9]{4})/(?P<sector>[\w\.-]*)/(?P<selected_month>[\w\.-]*)/$',
         'leaderboard.views.latest_leaderboard', name="all"),
 
     # individual company pages by year
-    url(r'^companies/(?P<year>[\w\.-]*)/$', 'leaderboard.views.company', name="allcompany"),
-    url(r'^companies/(?P<year>[\w\.-]*)/(?P<employerid>[\w\.-]*)/$', 'leaderboard.views.company', name="companies"),
-    url(r'^companies/(?P<year>[\w\.-]*)/(?P<employerid>[\w\.-]*)/(?P<teamid>[\w\.-]*)/$', 'leaderboard.views.company', name="teams"),
+    url(r'^companies/(?P<year>[0-9]{4})/$', 'leaderboard.views.company', name="allcompany"),
+    url(r'^companies/(?P<year>[0-9]{4})/(?P<employerid>[\w\.-]*)/$', 'leaderboard.views.company', name="companies"),
+    url(r'^companies/(?P<year>[0-9]{4})/(?P<employerid>[\w\.-]*)/(?P<teamid>[\w\.-]*)/$', 'leaderboard.views.company', name="teams"),
 
     # Admin
     url(r'^admin/', include(admin.site.urls)),

--- a/leaderboard/templates/company.html
+++ b/leaderboard/templates/company.html
@@ -16,7 +16,7 @@
 <div class="row clearfix">
     <div class="col-sm-12 column">
         <center>
-          <h1>Walk/Ride Day 2015 <br><strong>{{company.name}}</strong></h1>
+          <h1>Walk/Ride Day {{ year }} <br><strong>{{company.name}}</strong></h1>
           {% if company.nr_members %}
           <p>{{company.nr_members | intcomma}} team members eligible to participate</p>
           {% elif company.nr_employees %}
@@ -85,7 +85,7 @@
               <ul class="plot-container">
                 {% if datapoint.1|length = 1 %}
                   {# we're showing april only here #}
-                  <p><span style="font-size: 2em;">{{ datapoint.1.0.1 |floatformat:0}}%</span> in April 2015</p>
+                  <p><span style="font-size: 2em;">{{ datapoint.1.0.1 |floatformat:0}}%</span> in April</p>
                 {% else %}
                   {%  for month in datapoint.1 %}
                     <li data-cp-size="{{ month.1 | floatformat:0 | default:"0" }}"><span class="plot-label">{{ month.0|capfirst }}<br>{{ month.1 | default:"0" }}%</span></li>

--- a/leaderboard/templates/leaderboard/leaderboard_new.html
+++ b/leaderboard/templates/leaderboard/leaderboard_new.html
@@ -39,7 +39,7 @@
 
 <div class="row clearfix">
     <div class="col-md-12 column">
-        <center><h1>Walk/Ride Day 2015 <br>Corporate Challenge Leaderboard</h1>
+        <center><h1>Walk/Ride Day {{ year }} <br>Corporate Challenge Leaderboard</h1>
     </div>
 </div>
 
@@ -48,20 +48,20 @@
 <div class="lb-filter-container"><p><strong>By Month:</strong></p>
   <select id="checkin_month" name="checkin_month" class="lb-filter">
     {% if parent %}
-     <option value="{% url 'leaderboard.views.latest_leaderboard' sector=selected_sector size=size selected_month='all' parentid=parent.id %}"
+     <option value="{% url 'leaderboard.views.latest_leaderboard' year=year sector=selected_sector size=size selected_month='all' parentid=parent.id %}"
         {% if selected_month == 'all' %}selected="selected"{% endif %}>
     {% else %}
-     <option value="{% url 'leaderboard.views.latest_leaderboard' sector=selected_sector size=size selected_month='all' %}"
+     <option value="{% url 'leaderboard.views.latest_leaderboard' year=year sector=selected_sector size=size selected_month='all' %}"
         {% if selected_month == 'all' %}selected="selected"{% endif %}>
     {% endif %}
         All Months
     </option>
   {% for month in months_list  %}
     {% if parent %}
-     <option value="{% url 'leaderboard.views.latest_leaderboard' sector=selected_sector size=size selected_month=month parentid=parent.id %}"
+     <option value="{% url 'leaderboard.views.latest_leaderboard' year=year sector=selected_sector size=size selected_month=month parentid=parent.id %}"
         {% if selected_month == month %}selected="selected"{% endif %}>
     {% else %}
-     <option value="{% url 'leaderboard.views.latest_leaderboard' sector=selected_sector size=size selected_month=month %}"
+     <option value="{% url 'leaderboard.views.latest_leaderboard' year=year sector=selected_sector size=size selected_month=month %}"
         {% if selected_month == month %}selected="selected"{% endif %}>
     {% endif %}
          {{ month|capfirst }}
@@ -72,12 +72,12 @@
 
 <div class="lb-filter-container"><p><strong>By Company Size:</strong></p>
   <select id="company_size" name="company_size" class="lb-filter">
-     <option value="{% url 'leaderboard.views.latest_leaderboard' sector=selected_sector size='all' selected_month=selected_month %}"
+     <option value="{% url 'leaderboard.views.latest_leaderboard' year=year sector=selected_sector size='all' selected_month=selected_month %}"
         {% if size == 'all' %}selected="selected"{% endif %}>
         All Sizes
     </option>
   {% for item in sizes_list %}
-     <option value="{% url 'leaderboard.views.latest_leaderboard' sector=selected_sector size=item.0 selected_month=selected_month %}"
+     <option value="{% url 'leaderboard.views.latest_leaderboard' year=year sector=selected_sector size=item.0 selected_month=selected_month %}"
         {% if size == item.0 %}selected="selected"{% endif %}>
          {{ item.1 }}
      </option>
@@ -88,12 +88,12 @@
 
   <div class="lb-filter-container"><p><strong>By Company Sector:</strong></p>
     <select id="sector_selection" name="sector_selection" class="lb-filter">
-       <option value="{% url 'leaderboard.views.latest_leaderboard' sector='all' size=size selected_month=selected_month %}"
+       <option value="{% url 'leaderboard.views.latest_leaderboard' year=year sector='all' size=size selected_month=selected_month %}"
           {% if selected_sector == 'all' %}selected="selected"{% endif %}>
           All Sectors
       </option>
     {% for key, value in sectors_list.items %}
-       <option value="{% url 'leaderboard.views.latest_leaderboard' sector=key size=size selected_month=selected_month %}"
+       <option value="{% url 'leaderboard.views.latest_leaderboard' year=year sector=key size=size selected_month=selected_month %}"
           {% if selected_sector == key %}selected="selected"{% endif %}>
            {{ value }}
        </option>
@@ -103,11 +103,11 @@
 
   <div class="lb-filter-container"><p><strong>Looking for a Sub-Team?</strong></p>
     <select id="team_parent" name="team_parent" class="lb-filter">
-      <option value="{% url 'leaderboard.views.latest_leaderboard' sector='all' size='all' selected_month=selected_month %}">
+      <option value="{% url 'leaderboard.views.latest_leaderboard' year=year sector='all' size='all' selected_month=selected_month %}">
           Select a Sub-Team
       </option>
     {% for employer in employersWithSubteams %}
-       <option value="{% url 'leaderboard.views.latest_leaderboard' sector='all' size='all' selected_month=selected_month parentid=employer.id %}"
+       <option value="{% url 'leaderboard.views.latest_leaderboard' year=year sector='all' size='all' selected_month=selected_month parentid=employer.id %}"
            {% if employer.name == parent.name %}selected="selected"{% endif %}>
            {{employer.name}}
        </option>
@@ -146,14 +146,14 @@
     <h4>Average Participation To Date</h4>
     <ol class="lbrank">
     {% for key, value in ranks.percent_avg_participation %}
-      <li class="clearfix"><a class="list-group-item company" href="{% url 'leaderboard.views.company' employerid=key.1.0 teamid=key.1.1 %}">{{ key.0 }}<span class="badge">{{ value|floatformat:1 }}%</span></a></li>
+      <li class="clearfix"><a class="list-group-item company" href="{% url 'leaderboard.views.company' year=year employerid=key.1.0 teamid=key.1.1 %}">{{ key.0 }}<span class="badge">{{ value|floatformat:1 }}%</span></a></li>
     {% endfor %}
     </ol>
   {% else %}
     <h4>Staff Participation</h4>
     <ol class="lbrank">
     {% for key, value in ranks.percent_participation %}
-      <li class="clearfix"><a class="list-group-item company" href="{% url 'leaderboard.views.company' employerid=key.1.0 teamid=key.1.1 %}">{{ key.0 }}<span class="badge">{{ value|floatformat:1 }}%</span></a></li>
+      <li class="clearfix"><a class="list-group-item company" href="{% url 'leaderboard.views.company' year=year employerid=key.1.0 teamid=key.1.1 %}">{{ key.0 }}<span class="badge">{{ value|floatformat:1 }}%</span></a></li>
     {% endfor %}
     </ol>
   {% endif %}
@@ -162,7 +162,7 @@
     <h4>Green Commutes</h4>
     <ol class="lbrank">
     {% for key, value in ranks.percent_green_commuters %}
-      <li class="clearfix"><a class="list-group-item company" href="{% url 'leaderboard.views.company' employerid=key.1.0 teamid=key.1.1 %}">{{ key.0 }}<span class="badge">{{ value|floatformat:1 }}%</span></a></li>
+      <li class="clearfix"><a class="list-group-item company" href="{% url 'leaderboard.views.company' year=year employerid=key.1.0 teamid=key.1.1 %}">{{ key.0 }}<span class="badge">{{ value|floatformat:1 }}%</span></a></li>
     {% endfor %}
     </ol>
   </div>
@@ -170,7 +170,7 @@
     <h4>Greener Switches</h4>
     <ol class="lbrank">
     {% for key, value in ranks.percent_green_switches %}
-      <li class="clearfix"><a class="list-group-item company" href="{% url 'leaderboard.views.company' employerid=key.1.0 teamid=key.1.1 %}">{{ key.0}}<span class="badge">{{ value|floatformat:1 }}%</span></a></li>
+      <li class="clearfix"><a class="list-group-item company" href="{% url 'leaderboard.views.company' year=year employerid=key.1.0 teamid=key.1.1 %}">{{ key.0}}<span class="badge">{{ value|floatformat:1 }}%</span></a></li>
     {% endfor %}
     </ol>
   </div>
@@ -178,14 +178,14 @@
     <h4>Healthier Switches</h4>
     <ol class="lbrank">
     {% for key, value in ranks.percent_healthy_switches %}
-      <li class="clearfix"><a class="list-group-item company" href="{% url 'leaderboard.views.company' employerid=key.1.0 teamid=key.1.1 %}">{{ key.0 }}<span class="badge">{{ value|floatformat:1 }}%</span></a></li>
+      <li class="clearfix"><a class="list-group-item company" href="{% url 'leaderboard.views.company' year=year employerid=key.1.0 teamid=key.1.1 %}">{{ key.0 }}<span class="badge">{{ value|floatformat:1 }}%</span></a></li>
     {% endfor %}
     </ol>
   </div>
 
   <div class="col-sm-8 col-sm-offset-2">
     <center>
-      <div class="panel">Looking for data on a team you don't see here? <br><a href="{% url 'leaderboard.views.company' %}">Click to see all participating organizations</a>!</div>
+      <div class="panel">Looking for data on a team you don't see here? <br><a href="{% url 'leaderboard.views.company' year=year %}">Click to see all participating organizations</a>!</div>
     </center>
   </div>
 

--- a/leaderboard/templates/pick_company.html
+++ b/leaderboard/templates/pick_company.html
@@ -13,7 +13,7 @@
 
 <div class="row clearfix">
     <div class="col-md-12 column">
-        <center><h1>Walk/Ride Day 2015 <br>Corporate Challenge<br><strong>All participating companies and sub-teams</strong></h1>
+        <center><h1>Walk/Ride Day {{ year }} <br>Corporate Challenge<br><strong>All participating companies and sub-teams</strong></h1>
     </div>
 </div>
 
@@ -27,11 +27,11 @@
     {{ company.name }}
     <ul>
       {% for team in company.team_set.all %}
-        <li><a href="{% url 'leaderboard.views.company' employerid=company.id teamid=team.id %}">{{ team.name }}</a></li>
+        <li><a href="{% url 'leaderboard.views.company' year=year employerid=company.id teamid=team.id %}">{{ team.name }}</a></li>
       {% endfor %}
     </ul>
     {% else %}
-      <a href="{% url 'leaderboard.views.company' employerid=company.id %}">{{ company.name }}</a>
+      <a href="{% url 'leaderboard.views.company' year=year employerid=company.id %}">{{ company.name }}</a>
     {% endif %}
   </li>
 {% endfor %}
@@ -39,5 +39,3 @@
 </div>
 </div>
 {% endblock %}
-
-

--- a/survey/templates/survey/thanks.html
+++ b/survey/templates/survey/thanks.html
@@ -26,14 +26,14 @@
 
 
         <a id="checkin-another" class="btn btn-large btn-primary" href="/checkin/">Check in another person</a>
-        <a class="btn btn-large btn-warning" href="/leaderboard/">View Leaderboard</a>
+        <a class="btn btn-large btn-warning" href="/leaderboard/2016/">View Leaderboard</a>
         <hr>
         <!-- Information about retail partners rewards. Personal codes here? -->
 
         <p class="lead"><strong>Celebrate with our <a href="http://checkin-greenstreets.rhcloud.com/retail">retail partners</a> offering special discounts for Walk/Ride Day participants.</strong></p>
         <br>
         <a href="http://checkin-greenstreets.rhcloud.com/retail" target="_blank">View our retail map for discounts!</a>
-           
+
       </div>
     </div>
 </section>


### PR DESCRIPTION
Everything that was hardcoded to 2015 is no longer..

`leaderboard/2015/` will go to the 2015 leaderboard
`leaderboard/2016/` will go to the 2016 leaderboard
`companies/2015/` shows companies participating in the challenge in 2015, linking to their results for 2015
`companies/2016/` shows companies participating in the challenge in 2016, linking to their results for 2016

Any functions making calculations scoped to month are adjusted to also scope to year.
