### PR TITLE
redirect "/leaderboard/" to "/leaderboard/2016/"

### DIFF
--- a/checkin2015/urls.py
+++ b/checkin2015/urls.py
@@ -18,7 +18,7 @@ urlpatterns = patterns(
     url(r'^checkin/complete/$', TemplateView.as_view(template_name='survey/thanks.html'), name='complete'),
 
     # Leaderboard by year
-    url(r'^leaderboard/(?P<year>[0-9]{4})/$',
+    url(r'^leaderboard/((?P<year>[0-9]{4})/)?$',
         'leaderboard.views.latest_leaderboard', name="all"),
 
 

--- a/leaderboard/views.py
+++ b/leaderboard/views.py
@@ -7,6 +7,7 @@ from django.template import RequestContext
 from django.db.models import Q
 from aggregate_if import Count, Sum
 from django.db.models import Count
+from django.shortcuts import redirect
 
 from datetime import date, datetime
 import datetime
@@ -195,6 +196,9 @@ def company(request, year=2016, employerid=None, teamid=None):
 def latest_leaderboard(request, year=2016, sector='all', size='all', parentid=None, selected_month='all'):
     # Obtain the context from the HTTP request.
     context = RequestContext(request)
+
+    if year is None:
+        return redirect('2016/')
 
     d = {}
 


### PR DESCRIPTION
Quick and dirty fix.  The current year is hardcoded twice, should be fixed in a later commit.
