### PR TITLE
Add Question of the Month

### DIFF
--- a/survey/admin.py
+++ b/survey/admin.py
@@ -9,7 +9,7 @@ from django.db.models import Sum, Count
 
 from django.forms import ModelForm
 
-from survey.models import Commutersurvey, Employer, Leg, Month, Mode, Team, Sector
+from survey.models import Commutersurvey, Employer, Leg, Month, Mode, Team, Sector, QuestionOfTheMonth
 
 # disable deletion of records
 admin.site.disable_action('delete_selected')
@@ -87,6 +87,12 @@ class SectorAdmin(admin.ModelAdmin):
     list_editable = ['name']
     actions = [export_as_csv]
 
+# add admin configuration for QOTM
+class QOTMAdmin(admin.ModelAdmin):
+    list_display = ['id', 'wr_day_month', 'value']
+    list_editable = ['wr_day_month','value']
+    actions = [export_as_csv]
+
 admin.site.register(Commutersurvey, CommutersurveyAdmin)
 admin.site.register(Employer, EmployerAdmin)
 admin.site.register(Month, MonthAdmin)
@@ -94,3 +100,4 @@ admin.site.register(Leg, LegAdmin)
 admin.site.register(Mode, ModeAdmin)
 admin.site.register(Team, TeamAdmin)
 admin.site.register(Sector, SectorAdmin)
+admin.site.register(QuestionOfTheMonth, QOTMAdmin)

--- a/survey/forms.py
+++ b/survey/forms.py
@@ -1,7 +1,8 @@
 from django import forms
 from django.forms import ModelForm, HiddenInput
 
-from survey.models import Commutersurvey, Employer, Team, Leg
+from survey.models import Commutersurvey, Employer, Team, Leg, QuestionOfTheMonth
+from survey.utils import *
 from django.forms.models import inlineformset_factory
 from django.forms.models import BaseInlineFormSet
 from django.db.models import Q
@@ -114,7 +115,7 @@ class CommuterForm(ModelForm):
 class ExtraCommuterForm(ModelForm):
     class Meta:
         model = Commutersurvey
-        fields = ['comments', 'volunteer']
+        fields = ['comments', 'share', 'volunteer']
 
         # TODO: Take into account day and not just month
         if not datetime.now().month < 4 or datetime.now().month > 10:
@@ -126,16 +127,16 @@ class ExtraCommuterForm(ModelForm):
         if 'share' in self.fields:
             self.fields['share'].label = (
                 "Please don't share my identifying information with my employer")
-        self.fields['comments'].label = "Add a comment"
+
+        current_question = QuestionOfTheMonth.objects.get(wr_day_month=current_or_next_month()).value
+
+        self.fields['comments'].label = "Question of the Month: " + current_question
+        self.fields['comments'].widget.attrs['rows'] = 4
+        self.fields['comments'].widget.attrs['class'] = 'form-control'
+
         self.fields['volunteer'].label = (
             "Please contact me with information on ways to help or volunteer"
             " with Green Streets Initiative")
-        self.fields['comments'].widget.attrs['placeholder'] = (
-            "April's question-of-the-month: If you could designate a road in the Greater Boston Area (or in your area if you are elsewhere) to have a safe-for-biking lane, which road or stretch of road would you pick?")
-        self.fields['comments'].widget.attrs['rows'] = 4
-
-        # add CSS classes for bootstrap
-        self.fields['comments'].widget.attrs['class'] = 'form-control'
 
 class RequiredFormSet(BaseInlineFormSet):
     def __init__(self, *args, **kwargs):

--- a/survey/forms.py
+++ b/survey/forms.py
@@ -128,9 +128,13 @@ class ExtraCommuterForm(ModelForm):
             self.fields['share'].label = (
                 "Please don't share my identifying information with my employer")
 
-        current_question = QuestionOfTheMonth.objects.get(wr_day_month=current_or_next_month()).value
+        try:
+            current_question = QuestionOfTheMonth.objects.get(wr_day_month=current_or_next_month())
+            form_question = 'Question of the Month: ' + current_question.value
+        except:
+            form_question = 'Comment'
 
-        self.fields['comments'].label = "Question of the Month: " + current_question
+        self.fields['comments'].label = form_question
         self.fields['comments'].widget.attrs['rows'] = 4
         self.fields['comments'].widget.attrs['class'] = 'form-control'
 

--- a/survey/migrations/0009_questionofthemonth.py
+++ b/survey/migrations/0009_questionofthemonth.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('survey', '0008_auto_20160124_1941'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='QuestionOfTheMonth',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('value', models.TextField(default=b'', null=True, blank=True)),
+                ('wr_day_month', models.ForeignKey(default=0, blank=True, to='survey.Month', null=True)),
+            ],
+            options={
+            },
+            bases=(models.Model,),
+        ),
+    ]

--- a/survey/models.py
+++ b/survey/models.py
@@ -395,3 +395,11 @@ class Leg(models.Model):
         self.checkin.save()
     def __unicode__(self):
         return u"%s, %s, %s" % (self.mode, self.day, self.direction)
+
+# Model for QuestionOfTheMonth
+class QuestionOfTheMonth(models.Model):
+    wr_day_month = models.ForeignKey('Month', blank=True, null=True, default=0)
+    value = models.TextField(blank=True, null=True, default='')
+
+    def __unicode__(self):
+        return u"%s (%s)" % (self.value, self.wr_day_month)

--- a/survey/tests.py
+++ b/survey/tests.py
@@ -139,3 +139,22 @@ class LegTests(TestCase):
         self.assertLessEqual(self.decimal_places(checkin.calorie_change), 3)
         self.assertLessEqual(self.decimal_places(checkin.carbon_savings), 3)
         self.assertLessEqual(self.decimal_places(checkin.calories_total), 3)
+
+class QOTMTests(TestCase):
+    def make_month(self):
+        # Make sure there is a Month object in the database that
+        # lets the checkin be open at the time of the test.
+        now = datetime.datetime.now()
+        yesterday = now - datetime.timedelta(days=1)
+        tomorrow = now + datetime.timedelta(days=1)
+        m = models.Month.objects.create(wr_day=now, open_checkin=yesterday, close_checkin=tomorrow)
+        return m
+
+    def test_create_qotm(self):
+        month = self.make_month()
+        question = "What do you think about bikes?"
+        q = models.QuestionOfTheMonth.objects.create(wr_day_month=month, value=question)
+        self.assertEqual(q.wr_day_month, month)
+        self.assertEqual(q.value, "What do you think about bikes?")
+
+    # TODO test that the view shows the relevant question on the form

--- a/survey/tests.py
+++ b/survey/tests.py
@@ -18,7 +18,6 @@ class SessionTestCase(TestCase):
         store.save()
         self.session = store
         self.client.cookies[settings.SESSION_COOKIE_NAME] = store.session_key
-        self.opencheckin()
 
 class CheckinViewTestCase(SessionTestCase):
 

--- a/survey/utils.py
+++ b/survey/utils.py
@@ -1,6 +1,21 @@
-# Utility functions used across this app!
+from survey.models import Month
+from datetime import date
 
 # round stored values to 3 decimal places for
 # better human readability of the data dumps
 def sanely_rounded(float):
     return round(float, 3)
+
+def current_month():
+    return Month.objects.get(open_checkin__lte=date.today(), close_checkin__gte=date.today())
+
+def next_month():
+    return Month.objects.filter(open_checkin__gt=date.today()).order_by('wr_day')[0]
+
+def current_or_next_month():
+    if current_month():
+        return current_month()
+    elif next_month():
+        return next_month()
+    else:
+        return None

--- a/survey/utils.py
+++ b/survey/utils.py
@@ -1,16 +1,34 @@
-from survey.models import Month
-from datetime import date
+import datetime
 
 # round stored values to 3 decimal places for
 # better human readability of the data dumps
 def sanely_rounded(float):
     return round(float, 3)
 
+def this_month():
+    # lets the checkin be open at the time of this function being invoked.
+    if current_month():
+        return current_month()
+    else:
+        from survey.models import Month
+        now = datetime.datetime.now()
+        yesterday = now - datetime.timedelta(days=1)
+        tomorrow = now + datetime.timedelta(days=1)
+        return Month.objects.create(wr_day=now, open_checkin=yesterday, close_checkin=tomorrow)
+
 def current_month():
-    return Month.objects.get(open_checkin__lte=date.today(), close_checkin__gte=date.today())
+    from survey.models import Month
+    try:
+        return Month.objects.get(open_checkin__lte=datetime.date.today(), close_checkin__gte=datetime.date.today())
+    except:
+        return False
 
 def next_month():
-    return Month.objects.filter(open_checkin__gt=date.today()).order_by('wr_day')[0]
+    from survey.models import Month
+    try:
+        return Month.objects.filter(open_checkin__gt=datetime.date.today()).order_by('wr_day')[0]
+    except:
+        return False
 
 def current_or_next_month():
     if current_month():


### PR DESCRIPTION
Building off of @hhl60492's work, this PR adds a new model for handling the Question of the Month. Each `QuestionOfTheMonth` has two attributes - `wr_day_month` (ForeignKey to a `Month`), and `value` (the text of the question itself), and is editable in the admin page.

Note this does not replace the `comments` attribute on the `Commutersurvey` model. I left that alone. I did edit the form to find the current month's `QuestionOfTheMonth` and use that `value` as the form label for the comments box.

I'd like a few more tests on this, probably after merging in some of the other pull requests.

Extra thing: Added some utility functions to be able to easily fetch what the current or next `Month` is.
