### PR TITLE
add an alert when trying to check in without a sub team

### DIFF
--- a/survey/mommy_recipes.py
+++ b/survey/mommy_recipes.py
@@ -1,5 +1,5 @@
 from model_mommy.recipe import Recipe
-from survey.models import Leg, Commutersurvey
+from survey.models import Leg, Commutersurvey, Employer
 
 # Define recipes for use with model_mommy here
 # http://model-mommy.readthedocs.io/en/latest/recipes.html


### PR DESCRIPTION
It won't let you check in until you indicate a subteam.

![image](https://cloud.githubusercontent.com/assets/2136286/15372704/b4ad4814-1d0f-11e6-8746-324456c3bbb1.png)

It also no longer clears the value for the sub-team `<select>` on load, which means cookies should actually work for it now... 
