### PR TITLE
Add transportation category to retail partners map

### DIFF
--- a/retail/static/retail/js/main.js
+++ b/retail/static/retail/js/main.js
@@ -229,6 +229,12 @@ var retailPartnerData = function(data, isMobile, isTablet){
 				prefix: 'fa',
 				markerColor: 'darkgreen'
 			}),
+			"Transportation": L.AwesomeMarkers.icon({
+				icon: 'bus',
+				iconColor: 'white',
+				prefix: 'fa',
+				markerColor: 'gray'
+			}),
 			"Unused": L.AwesomeMarkers.icon({
 				icon: 'shopping-cart',
 				iconColor: 'white',

--- a/retail/templates/retail/index.html
+++ b/retail/templates/retail/index.html
@@ -10,7 +10,7 @@
 	<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css">
 
 		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.css" />
-		<link rel="stylesheet" type="text/css" href="//cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.0/leaflet.awesome-markers.css">
+		<link rel="stylesheet" type="text/css" href="//cdnjs.cloudflare.com/ajax/libs/Leaflet.awesome-markers/2.0.2/leaflet.awesome-markers.css">
 
 	<link rel="stylesheet" href="{% static 'css/fonts.css' %}" type="text/css" charset="utf-8" />
 	<link rel="stylesheet" href="{% static 'retail/css/style.css' %}">


### PR DESCRIPTION
As in the title. I believe Sophie told me yesterday she wanted the marker to be gray. I had to update the Leaflet.awesome-markers dependency to a newer version in order to use gray as a marker color. It looks like this on my machine:

![greenstreetsmarker](https://user-images.githubusercontent.com/35127144/54374132-7e2f5200-464c-11e9-81b5-a864848871ce.png)
