### PR TITLE
fixed html bug effecting firefox

### DIFF
--- a/retail/static/retail/js/main.js
+++ b/retail/static/retail/js/main.js
@@ -576,7 +576,7 @@ retailPartnerData.prototype.display = function() {
 				content += "<p class=\"rp-name\">" + "<input type=\"checkbox\" name=\"acs\" value=\"" + this.retailPartners[i].name + "\"" + "/>" + this.retailPartners[i].name + "</p>";
 			}
 			else {
-				content += "<a  href=\""+ this.retailPartners[i].website +"\" class=\"rp-name-url\">" + "<input type=\"checkbox\" name=\"acs\" value=\"" + this.retailPartners[i].name + "\"/>" + this.retailPartners[i].name + "</a>";
+				content += "<input type=\"checkbox\" name=\"acs\" value=\"" + this.retailPartners[i].name + "\"/>" + "<a href=\""+ this.retailPartners[i].website +"\" class=\"rp-name-url\">" + this.retailPartners[i].name + "</a>";
 			}
 			content += "<p class=\"rp-p\">"+this.retailPartners[i].address+"</p>"+"<p class=\"rp-p\">"+this.retailPartners[i].offer+"</p>"
 			if(this.retailPartners[i].distance != Math.Infinity){	// If we've calculated the distance, show it.


### PR DESCRIPTION
An `<a>` tag included the input checkbox as a child element on the retail page. Chrome seems to be able to fix this on the fly so that checking the box does not open the link, but Firefox does not. I rewrote it so the `<a>` is a sibling of the `<input>`